### PR TITLE
Add support for SPM through Package.resolved

### DIFF
--- a/lib/licensed/sources/cocoapods.rb
+++ b/lib/licensed/sources/cocoapods.rb
@@ -39,12 +39,14 @@ module Licensed
       def cocoapods_dependencies_json
         args = ["dependencies", "--include-path"]
         args << "--targets=#{targets.join(",")}" if targets.any?
-
+        puts "pod_command: #{pod_command}"
+        puts "args: #{args}"
         output = Licensed::Shell.execute(*pod_command, *args, allow_failure: true)
         if output.include? "Unknown command"
           raise Licensed::Sources::Source::Error, MISSING_PLUGIN_MESSAGE
         end
 
+        puts "args: #{output}"
         JSON.parse(output)
       rescue JSON::ParserError => e
         message = "Licensed was unable to parse the output from 'pod dependencies'. JSON Error: #{e.message}"

--- a/lib/licensed/sources/cocoapods.rb
+++ b/lib/licensed/sources/cocoapods.rb
@@ -39,14 +39,12 @@ module Licensed
       def cocoapods_dependencies_json
         args = ["dependencies", "--include-path"]
         args << "--targets=#{targets.join(",")}" if targets.any?
-        puts "pod_command: #{pod_command}"
-        puts "args: #{args}"
+
         output = Licensed::Shell.execute(*pod_command, *args, allow_failure: true)
         if output.include? "Unknown command"
           raise Licensed::Sources::Source::Error, MISSING_PLUGIN_MESSAGE
         end
 
-        puts "args: #{output}"
         JSON.parse(output)
       rescue JSON::ParserError => e
         message = "Licensed was unable to parse the output from 'pod dependencies'. JSON Error: #{e.message}"

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -7,15 +7,16 @@ module Licensed
   module Sources
     class Swift < Source
       def enabled?
-        return unless Licensed::Shell.tool_available?("swift") && swift_package?
+        return unless Licensed::Shell.tool_available?("xcodebuild")
+        @derived_data_path = get_derived_data_path
         File.exist?(package_resolved_file_path)
       end
 
       def enumerate_dependencies
         pins.map { |pin|
-          name = pin["package"]
+          name = pin["identity"]
           version = pin.dig("state", "version")
-          path = dependency_path_for_url(pin["repositoryURL"])
+          path = dependency_path_for_url(pin["location"])
           error = "Unable to determine project path from #{url}" unless path
 
           Dependency.new(
@@ -25,7 +26,7 @@ module Licensed
             errors: Array(error),
             metadata: {
               "type"      => Swift.type,
-              "homepage"  => homepage_for_url(pin["repositoryURL"])
+              "homepage"  => homepage_for_url(pin["location"])
             }
           )
         }
@@ -38,7 +39,7 @@ module Licensed
 
         @pins = begin
           json = JSON.parse(File.read(package_resolved_file_path))
-          json.dig("object", "pins")
+          json.dig("pins")
         rescue => e
           message = "Licensed was unable to read the Package.resolved file. Error: #{e.message}"
           raise Licensed::Sources::Source::Error, message
@@ -46,8 +47,8 @@ module Licensed
       end
 
       def dependency_path_for_url(url)
-        last_path_component = URI(url).path.split("/").last.sub(/\.git$/, "")
-        File.join(config.pwd, ".build", "checkouts", last_path_component)
+        last_path_component = URI(url).path.split("/").last.sub(/\.git$/, "").rstrip
+        File.join(@derived_data_path, "SourcePackages", "checkouts", last_path_component)
       rescue URI::InvalidURIError
       end
 
@@ -58,11 +59,11 @@ module Licensed
       end
 
       def package_resolved_file_path
-        File.join(config.pwd, "Package.resolved")
+        File.join(config.pwd, "ios.xcworkspace/xcshareddata/swiftpm", "Package.resolved")
       end
 
-      def swift_package?
-        Licensed::Shell.success?("swift", "package", "describe")
+      def derived_data_path
+        %x(xcodebuild -showBuildSettings $@ | grep -m 1 "BUILD_DIR" | grep -oEi "\/.*" | sed 's#/Build/Products##').rstrip
       end
     end
   end

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -8,7 +8,7 @@ module Licensed
     class Swift < Source
       def enabled?
         return unless Licensed::Shell.tool_available?("xcodebuild")
-        @derived_data_path = get_derived_data_path
+        @derived_data_path = derived_data_path
         File.exist?(package_resolved_file_path)
       end
 

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -69,7 +69,7 @@ module Licensed
 
       def set_derived_data_path
         build_dir =  JSON.parse(`xcodebuild -showBuildSettings $@ -json`).first.dig("buildSettings", "BUILD_DIR")
-        @derived_data_path ||= build_dir.delete_suffix("/Build/Products")
+        @derived_data_path = build_dir.delete_suffix("/Build/Products")
       end
     end
   end


### PR DESCRIPTION
Le support de swift package dans Licensed a été configuré pour fonctionner avec un fichier Package.swift. 

C'était la seule façon d'utiliser swift package manager (SPM) dans les débuts. Le Package.swift est l'équivalent d'un Gemfile. Il génère un fichier Package.resolved (l'équivalent d'un .lock) à la racine du projet.

Or, maintenant, Xcode supporte l'ajout de packages swift directement. C'est comme ça que nous utilisons SPM dans le projet iOS.

Ce qui n'est pas super, c'est que Xcode store le fichier Package.resolved (la liste de nos packages) dans un path un peu obscur (dans le fichier xcworkspace) ET qu'il install les packages dans un path encore plus obscur (dans les derived data, qui sont par exemple `/Users/mathbl/Library/Developer/Xcode/DerivedData/ios-gxzurxtbzihlfycrkidcggdpgrqo` ici). Le folder ajoute un hash/id au nom du projet.

**Ce que j'ai fait pour que ça fonctionne :**
- Modifié  `package_resolved_file_path` pour lui passer le path vers le Package.resolved
- Ajouté `derived_data_path` : ici, la gymnastique pour le déterminer nécessite d'utiliser xcodebuild. C'est pas génial, mais c'est la seule façon que j'ai trouvé pour aller chercher dynamiquement le path vers les derived data d'un projet. 
- Modifié le naming de divers champs, car les champs du Package.resolved généré par xcode ne sont pas les mêmes.

Je constate que, as-is, ma fork ne serait pas utilisable nécessairement par une autre entreprise. Je me demande s'il y aurait moyen (et si ça vaut la peine) de raffiner un peu le code pour que, par exemple, on puisse fournir le path vers le package.resolved en input (ou dans un config file). Mon ruby n'est pas super avancé. Je me disais qu'on pourrait aussi possiblement modifier licensed pour qu'on puisse lui dire qu'on veut utiliser une config Package.swift ou Xcode, mais encore là, est-ce que ça vaut la peine?